### PR TITLE
metrics reports as (tab|comma)-separated-values

### DIFF
--- a/api/metrics/renderers.py
+++ b/api/metrics/renderers.py
@@ -1,0 +1,73 @@
+import csv
+import io
+
+from django.http import Http404
+
+from rest_framework import renderers
+
+
+# put these fields first, then sort the rest alphabetically
+PRIORITIZED_FIELDNAMES = {'report_date', 'report_yearmonth', 'timestamp'}
+def csv_fieldname_sortkey(fieldname):
+    return (
+        (fieldname not in PRIORITIZED_FIELDNAMES),  # False ordered before True
+        fieldname,
+    )
+
+
+def get_nested_keys(report_attrs):
+    for attr_key in sorted(report_attrs.keys(), key=csv_fieldname_sortkey):
+        attr_value = report_attrs[attr_key]
+        if isinstance(attr_value, dict):
+            for subkey in get_nested_keys(attr_value):
+                yield f'{attr_key}.{subkey}'
+        else:
+            yield attr_key
+
+
+def get_key_value(nested_key, report_attrs):
+    (key, _, next_nested_key) = nested_key.partition('.')
+    attr_value = report_attrs.get(key, {})
+    return (
+        get_key_value(next_nested_key, attr_value)
+        if next_nested_key
+        else attr_value
+    )
+
+
+def get_csv_row(keys_list, report_attrs):
+    return [
+        get_key_value(key, report_attrs)
+        for key in keys_list
+    ]
+
+
+class MetricsReportsCsvRenderer(renderers.BaseRenderer):
+    media_type = 'text/csv'
+    format = 'csv'
+    CSV_DIALECT = csv.excel
+
+    def render(self, json_response, accepted_media_type=None, renderer_context=None):
+        serialized_reports = (
+            jsonapi_resource['attributes']
+            for jsonapi_resource in json_response['data']
+        )
+        try:
+            first_row = next(serialized_reports)
+        except StopIteration:
+            raise Http404('<h1>none found</h1>')
+        csv_fieldnames = list(get_nested_keys(first_row))
+        csv_filecontent = io.StringIO(newline='')
+        csv_writer = csv.writer(csv_filecontent, dialect=self.CSV_DIALECT)
+        csv_writer.writerow(csv_fieldnames)
+        for serialized_report in (first_row, *serialized_reports):
+            csv_writer.writerow(
+                get_csv_row(csv_fieldnames, serialized_report),
+            )
+        return csv_filecontent.getvalue()
+
+
+class MetricsReportsTsvRenderer(MetricsReportsCsvRenderer):
+    format = 'tsv'
+    media_type = 'text/tab-separated-values'
+    CSV_DIALECT = csv.excel_tab

--- a/api_tests/metrics/test_queries.py
+++ b/api_tests/metrics/test_queries.py
@@ -84,7 +84,7 @@ class TestNodeAnalyticsQuery:
         }
         resp = app.get(f'/_/metrics/query/node_analytics/{guid}/{timespan}/')
 
-        assert resp.json == {'data': {
+        assert resp.json['data'] == {
             'id': f'{guid}:{timespan}',
             'type': 'node-analytics',
             'attributes': {
@@ -106,6 +106,6 @@ class TestNodeAnalyticsQuery:
                     {'referer_domain': 'elsewhere.example.com', 'count': 4},
                 ],
             },
-        }}
+        }
 
         assert mock_search.call_count == 1

--- a/api_tests/metrics/test_reports.py
+++ b/api_tests/metrics/test_reports.py
@@ -53,8 +53,9 @@ class TestMetricsReports:
             },
         }
         resp = app.get(f'/_/metrics/reports/{report_name}/recent/')
-
-        assert resp.json == {'data': [
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'application/vnd.api+json; charset=utf-8'
+        assert resp.json['data'] == [
             {
                 'id': 'hi-by',
                 'type': f'daily-report:{report_name}',
@@ -70,4 +71,25 @@ class TestMetricsReports:
                     'hello': 'upwa',
                 },
             }
-        ]}
+        ]
+
+        resp = app.get(f'/_/metrics/reports/{report_name}/recent/?format=tsv')
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'text/tab-separated-values; charset=utf-8'
+        assert resp.unicode_body == TSV_REPORTS
+
+        resp = app.get(f'/_/metrics/reports/{report_name}/recent/?format=csv')
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'text/csv; charset=utf-8'
+        assert resp.unicode_body == CSV_REPORTS
+
+
+TSV_REPORTS = '''report_date	hello
+1234-12-12	goodbye
+1234-12-11	upwa
+'''.replace('\n', '\r\n')
+
+CSV_REPORTS = '''report_date,hello
+1234-12-12,goodbye
+1234-12-11,upwa
+'''.replace('\n', '\r\n')


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
allow download metrics reports as tsv/csv, for local spreadsheeting
<!-- Describe the purpose of your changes -->

## Changes
- add `api.metrics.renderers` with `MetricsReportsCsvRenderer` and `MetricsReportsTsvRenderer`
- update recent reports api view `/_/metrics/reports/{report_name}/recent`
  - add `?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD` query params
  - return a drf response, so content negotiation actually happens (either by header or `?format=csv`/`?format=tsv` query params)
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
- browsable api now works as expected
<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
