### PR TITLE
Fix sentry ...

### DIFF
--- a/addons/boa/tasks.py
+++ b/addons/boa/tasks.py
@@ -161,8 +161,7 @@ def handle_error(message, username, fullname, query_file_name,
     """Handle Boa and WB API errors and send emails.
     """
     logger.error(message)
-    sentry.log_message(message)
-    sentry.log_exception()
+    sentry.log_message(message, skip_session=True)
     send_mail(
         mail=ADDONS_BOA_JOB_FAILURE,
         to_addr=username,

--- a/framework/sentry/__init__.py
+++ b/framework/sentry/__init__.py
@@ -25,27 +25,26 @@ def get_session_data():
         return {}
 
 
-def log_exception():
+def log_exception(skip_session=False):
     if not enabled:
         logger.warning('Sentry called to log exception, but is not active')
         return None
+    extra = {
+        'session': {} if skip_session else get_session_data(),
+    }
+    return sentry.captureException(extra=extra)
 
-    return sentry.captureException(extra={
-        'session': get_session_data(),
-    })
 
-
-def log_message(message, extra_data=None, level=logging.ERROR):
+def log_message(message, skip_session=False, extra_data=None, level=logging.ERROR):
     if not enabled:
         logger.warning(
             'Sentry called to log message, but is not active: %s' % message
         )
         return None
     extra = {
-        'session': get_session_data(),
+        'session': {} if skip_session else get_session_data(),
     }
     if extra_data is None:
         extra_data = {}
     extra.update(extra_data)
-
     return sentry.captureMessage(message, extra=extra, level=level)


### PR DESCRIPTION
* Remove `log_exception()` since `log_message()` provides enough info
* Don't get session data since user's browser session is not relevant in this task